### PR TITLE
Support importing of fixed datasets

### DIFF
--- a/securedrop/bin/dev-deps
+++ b/securedrop/bin/dev-deps
@@ -163,9 +163,13 @@ function reset_demo() {
 
     gpg2 --homedir /var/lib/securedrop/keys --no-default-keyring --keyring /var/lib/securedrop/keys/pubring.gpg --import /var/lib/securedrop/journalist.pub
 
+    # Check if we should use fixed data instead of random data
+    if [ -n "${USE_FIXED_DATA:-""}" ]; then
+        echo "Loading fixed data from ${FIXED_DATA_CONTAINER_PATH}..."
+        ./loadfixeddata.py --yaml-path "${FIXED_DATA_CONTAINER_PATH}"
     # Can't pass an array environment variable with "docker --env", so
     # break up the string we can pass.
-    if [ -n "${LOADDATA_ARGS:-""}" ]
+    elif [ -n "${LOADDATA_ARGS:-""}" ]
     then
         IFS=" " read -r -a loaddata_arg_array <<< "${LOADDATA_ARGS}"
         ./loaddata.py "${loaddata_arg_array[@]}"

--- a/securedrop/bin/dev-shell
+++ b/securedrop/bin/dev-shell
@@ -116,6 +116,22 @@ function docker_run() {
         DOCKER_RUN_ARGUMENTS="${DOCKER_RUN_ARGUMENTS} -it"
     fi
 
+    # Handle fixed data paths
+    if [ -n "${USE_FIXED_DATA:-}" ]; then
+        # Resolve absolute path for the YAML file
+        FIXED_DATA_PATH="$(realpath "${USE_FIXED_DATA}")"
+
+        # Get the directory containing the YAML file
+        FIXED_DATA_DIR="$(dirname "${FIXED_DATA_PATH}")"
+        FIXED_DATA_FILE="$(basename "${FIXED_DATA_PATH}")"
+
+        # Mount the directory containing the YAML file
+        DOCKER_RUN_ARGUMENTS="${DOCKER_RUN_ARGUMENTS} --volume ${FIXED_DATA_DIR}:/fixed-data:Z"
+
+        # Set environment variable for the script to use the mounted path
+        DOCKER_RUN_ARGUMENTS="${DOCKER_RUN_ARGUMENTS} -e FIXED_DATA_CONTAINER_PATH=/fixed-data/${FIXED_DATA_FILE}"
+    fi
+
     if [ -n "${USE_TOR:-}" ]; then
         # Mount persistent onion services
         $DOCKER_BIN volume inspect sd-onion-services -f " " || $DOCKER_BIN volume create sd-onion-services
@@ -141,6 +157,7 @@ function docker_run() {
            -e NUM_JOURNALISTS \
            -e NUM_SOURCES \
            -e LOADDATA_ARGS \
+           -e USE_FIXED_DATA \
            -e LC_ALL=C.UTF-8 \
            -e LANG=C.UTF-8 \
            -e TEST_LOCALES \

--- a/securedrop/loadfixeddata.py
+++ b/securedrop/loadfixeddata.py
@@ -1,0 +1,341 @@
+#!/opt/venvs/securedrop-app-code/bin/python
+
+"""
+Loads fixed test data from a YAML file into the SecureDrop database.
+"""
+
+import argparse
+import datetime
+import io
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import journalist_app
+import yaml
+from db import db
+from encryption import EncryptionManager
+from models import (
+    Journalist,
+    Reply,
+    SeenFile,
+    SeenMessage,
+    SeenReply,
+    Source,
+    Submission,
+)
+from sdconfig import SecureDropConfig
+from source_user import create_source_user
+from store import Storage
+
+
+def verify_empty_database() -> None:
+    """Verify that the database is empty before importing data."""
+    tables_to_check = [
+        (Journalist, "journalists"),
+        (Source, "sources"),
+        (Submission, "submissions"),
+        (Reply, "replies"),
+        (SeenFile, "seen_files"),
+        (SeenMessage, "seen_messages"),
+        (SeenReply, "seen_replies"),
+    ]
+
+    non_empty_tables = []
+    for model, table_name in tables_to_check:
+        count = model.query.count()
+        if count > 0:
+            non_empty_tables.append(f"{table_name} ({count} records)")
+
+    if non_empty_tables:
+        raise RuntimeError(
+            f"Database is not empty. Found records in: {', '.join(non_empty_tables)}. "
+            "Please start with a clean database."
+        )
+
+
+def import_journalists(journalists_data: List[Dict[str, Any]]) -> Dict[str, Journalist]:
+    uuid_to_journalist = {}
+
+    print(f"Importing {len(journalists_data)} journalists...")
+
+    for i, journalist_data in enumerate(journalists_data, 1):
+        username = journalist_data["username"]
+        uuid = journalist_data["uuid"]
+        journalist = Journalist(
+            username=username,
+            password=journalist_data["passphrase"],
+            first_name=journalist_data["first_name"],
+            last_name=journalist_data["last_name"],
+            is_admin=bool(journalist_data["is_admin"]),
+        )
+        journalist.uuid = uuid
+        journalist.otp_secret = journalist_data["otp_secret"]
+        journalist.is_totp = True
+        journalist.created_on = datetime.datetime.fromisoformat(journalist_data["created_on"])
+
+        db.session.add(journalist)
+        uuid_to_journalist[uuid] = journalist
+
+        print(f"Imported journalist {i}/{len(journalists_data)}: {username}")
+
+    db.session.commit()
+    return uuid_to_journalist
+
+
+def import_sources(sources_data: List[Dict[str, Any]], yaml_dir: Path) -> Dict[str, Source]:
+    """Import sources from YAML data, loading PGP keys from separate files."""
+    uuid_to_source = {}
+
+    print(f"Importing {len(sources_data)} sources...")
+
+    for i, source_data in enumerate(sources_data, 1):
+        uuid = source_data["uuid"]
+        journalist_designation = source_data["journalist_designation"]
+        fingerprint = source_data["pgp_fingerprint"]
+
+        # Load PGP keys from paths relative to YAML file
+        public_key_path = source_data["pgp_public_key"]
+        secret_key_path = source_data["pgp_secret_key"]
+
+        public_key_file = yaml_dir / public_key_path
+        secret_key_file = yaml_dir / secret_key_path
+
+        public_key = public_key_file.read_text().strip()
+        secret_key = secret_key_file.read_text().strip()
+
+        # Create a source with real filesystem_id (using create_source_user)
+        # We'll use a dummy passphrase since we're overriding the PGP keys anyway
+        dummy_passphrase = f"dummy passphrase for {journalist_designation}"
+        source_user = create_source_user(
+            db_session=db.session,
+            source_passphrase=dummy_passphrase,
+            source_app_storage=Storage.get_default(),
+        )
+        source = source_user.get_db_record()
+
+        source.journalist_designation = journalist_designation
+        source.pgp_public_key = public_key
+        source.pgp_secret_key = secret_key
+        source.pgp_fingerprint = fingerprint
+        source.uuid = uuid
+        source.last_updated = datetime.datetime.fromisoformat(source_data["last_updated"])
+        source.pending = False
+
+        db.session.add(source)
+        uuid_to_source[uuid] = source
+
+        print(f"Imported source {i}/{len(sources_data)}: {journalist_designation}")
+
+    db.session.commit()
+    return uuid_to_source
+
+
+def record_source_interaction(source: Source) -> None:
+    source.interaction_count += 1
+    # unlike loaddata.py, we don't update last_updated here so it uses the YAML value
+    db.session.flush()
+
+
+def import_submissions_and_replies(
+    sources_data: List[Dict[str, Any]],
+    uuid_to_source: Dict[str, Source],
+    uuid_to_journalist: Dict[str, Journalist],
+) -> Tuple[Dict[str, Submission], Dict[str, Reply]]:
+    uuid_to_submission = {}
+    uuid_to_reply = {}
+    storage = Storage.get_default()
+    encryption_mgr = EncryptionManager.get_default()
+
+    # Count total items for progress tracking
+    total_items = sum(len(source_data["items"]) for source_data in sources_data)
+    submission_count = 0
+    reply_count = 0
+
+    print(f"Importing {total_items} items (messages, files, and replies)...")
+
+    for source_data in sources_data:
+        source = uuid_to_source[source_data["uuid"]]
+
+        for item_data in source_data["items"]:
+            uuid = item_data["uuid"]
+            kind = item_data["kind"]
+
+            # Record interaction (updates interaction_count, etc.)
+            record_source_interaction(source)
+
+            if kind == "message":
+                # Message submission
+                submission_count += 1
+                content = item_data["content"]
+                fpath = storage.save_message_submission(
+                    source.filesystem_id,
+                    source.interaction_count,
+                    source.journalist_filename,
+                    content,
+                )
+                submission = Submission(source, fpath, storage)
+                submission.uuid = uuid
+                submission.downloaded = item_data["downloaded"]
+
+                db.session.add(submission)
+                uuid_to_submission[uuid] = submission
+
+                print(f"Imported message submission: {fpath}")
+
+            elif kind == "file":
+                # File submission
+                submission_count += 1
+                file_content = item_data["file"]["content"]
+                original_filename = item_data["file"]["filename"]
+
+                # Create BytesIO from the content
+                file_bytes = file_content.encode("utf-8")
+                fpath = storage.save_file_submission(
+                    source.filesystem_id,
+                    source.interaction_count,
+                    source.journalist_filename,
+                    original_filename,
+                    io.BytesIO(file_bytes),
+                )
+                submission = Submission(source, fpath, storage)
+                submission.uuid = uuid
+                submission.downloaded = item_data["downloaded"]
+
+                db.session.add(submission)
+                uuid_to_submission[uuid] = submission
+
+                print(f"Imported file submission: {fpath}")
+
+            elif kind == "reply":
+                # Reply
+                reply_count += 1
+                journalist_uuid = item_data["journalist_uuid"].split(" ")[0]  # Remove comment part
+                journalist = uuid_to_journalist[journalist_uuid]
+                content = item_data["content"]
+
+                # Create filename for reply
+                fname = f"{source.interaction_count}-{source.journalist_filename}-reply.gpg"
+
+                # Create encrypted reply file using real SecureDrop encryption
+                encryption_mgr.encrypt_journalist_reply(
+                    for_source=source,
+                    reply_in=content,
+                    encrypted_reply_path_out=Path(storage.path(source.filesystem_id, fname)),
+                )
+
+                # Create reply using constructor
+                reply = Reply(journalist, source, fname, storage)
+                reply.uuid = uuid
+                reply.deleted_by_source = item_data["deleted_by_source"]
+
+                db.session.add(reply)
+                uuid_to_reply[uuid] = reply
+
+                print(f"Imported reply: {fname}")
+
+    db.session.commit()
+    print(f"Imported {submission_count} submissions and {reply_count} replies")
+    return uuid_to_submission, uuid_to_reply
+
+
+def import_seen_records(
+    sources_data: List[Dict[str, Any]],
+    uuid_to_submission: Dict[str, Submission],
+    uuid_to_reply: Dict[str, Reply],
+    uuid_to_journalist: Dict[str, Journalist],
+) -> None:
+    """Import seen records from seen_by arrays in items."""
+    seen_count = 0
+
+    # Process seen records from unified items list
+    for source_data in sources_data:
+        for item_data in source_data["items"]:
+            uuid = item_data["uuid"]
+            kind = item_data["kind"]
+            seen_by_uuids = item_data["seen_by"]
+
+            if seen_by_uuids:
+                for journalist_uuid in seen_by_uuids:
+                    journalist = uuid_to_journalist[journalist_uuid]
+
+                    if kind == "message":
+                        # Message submission
+                        submission = uuid_to_submission[uuid]
+                        seen_record = SeenMessage(message=submission, journalist=journalist)
+                        db.session.add(seen_record)
+                        seen_count += 1
+                    elif kind == "file":
+                        # File submission
+                        submission = uuid_to_submission[uuid]
+                        seen_record = SeenFile(file=submission, journalist=journalist)
+                        db.session.add(seen_record)
+                        seen_count += 1
+                    elif kind == "reply":
+                        # Reply
+                        reply = uuid_to_reply[uuid]
+                        seen_record = SeenReply(reply=reply, journalist=journalist)
+                        db.session.add(seen_record)
+                        seen_count += 1
+
+    print(f"Created {seen_count} seen records")
+    db.session.commit()
+
+
+def load_fixed_data(yaml_path: Path) -> None:
+    """Load fixed test data from YAML into the database."""
+    if not os.environ.get("SECUREDROP_ENV"):
+        os.environ["SECUREDROP_ENV"] = "dev"
+
+    config = SecureDropConfig.get_current()
+    app = journalist_app.create_app(config)
+
+    with app.app_context():
+        print("Loading fixed data from YAML...")
+
+        verify_empty_database()
+
+        with yaml_path.open("r") as f:
+            data = yaml.safe_load(f)
+        yaml_dir = yaml_path.parent
+
+        print("\n--- Importing journalists ---")
+        uuid_to_journalist = import_journalists(data["journalists"])
+
+        print("\n--- Importing sources ---")
+        uuid_to_source = import_sources(data["sources"], yaml_dir)
+
+        print("\n--- Importing items (messages, files, and replies) ---")
+        uuid_to_submission, uuid_to_reply = import_submissions_and_replies(
+            data["sources"], uuid_to_source, uuid_to_journalist
+        )
+
+        print("\n--- Importing seen records ---")
+        import_seen_records(data["sources"], uuid_to_submission, uuid_to_reply, uuid_to_journalist)
+
+        print("\n✓ Successfully imported fixed data:")
+        print(f"  - {len(uuid_to_journalist)} journalists")
+        print(f"  - {len(uuid_to_source)} sources")
+        print(f"  - {len(uuid_to_submission)} submissions")
+        print(f"  - {len(uuid_to_reply)} replies")
+
+
+def parse_arguments() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        Path(__file__).name,
+        description="Loads fixed test data from a YAML file into the database",
+    )
+    parser.add_argument(
+        "--yaml-path",
+        type=Path,
+        required=True,
+        help="Path to the YAML data file",
+    )
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    args = parse_arguments()
+    load_fixed_data(args.yaml_path)


### PR DESCRIPTION
> [!NOTE]
> This is a copy of freedomofpress/securedrop#7669 for testing GitHub Copilot.

loaddata.py generates a database with randomized data, which makes it difficult to write tests against. The new loadfixedata.py takes a dataset that's declared in a YAML file, invoke it via:

```
USE_FIXED_DATA=data.yaml make dev
```
The primary intent for this is to be used with the app.

Because it does override some data the script is not as efficient as it could be, for example create_source_user() generates a PGP keypair for the source, and then it's immediately overwritten by the keys supplied in the YAML.

Not every field is supported yet, the intent is that basically everything that would be exposed in APIv2 would be taken from the YAML.

There is a bit of logic added to dev-shell to ensure that even if the YAML file is in some other directory (e.g. the app), it still gets mounted into the container so the script can read from it.

Refs https://github.com/freedomofpress/securedrop-client/issues/2695.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] review in tandem with https://github.com/freedomofpress/securedrop-client/issues/2695, notably that this PR supports everything we need for the app.
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any required additional documentation
- [x] any necessary AppArmor changes (added or removed application files)
- [x] any impact on new SecureDrop installs and upgrades
- [x] our [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)

## AI usage

I dumped a normal database and then had Claude Code transform it to YAML, manually refined it down, and then had Claude take the YAML and create a script for it, based off of loaddata.py, which I then cleaned up.